### PR TITLE
Agregar uso limitado e ilimitado del Rol BattleReady

### DIFF
--- a/SysBot.Pokemon.Discord/Helpers/AccessListExtensions.cs
+++ b/SysBot.Pokemon.Discord/Helpers/AccessListExtensions.cs
@@ -1,0 +1,30 @@
+using Discord.WebSocket;
+using System;
+using System.Linq;
+
+namespace SysBot.Pokemon.Discord.Helpers
+{
+    public static class AccessListExtensions
+    {
+        public static bool IsUserAllowed(this SysBot.Pokemon.RemoteControlAccessList list, SocketUser user)
+        {
+            if (list == null) return false;
+            if (list.AllowIfEmpty) return true;
+
+            if (user is SocketGuildUser gu)
+            {
+                // By Role ID
+                foreach (var entry in list.List)
+                    if (entry.ID != 0 && gu.Roles.Any(r => r.Id == entry.ID))
+                        return true;
+
+                // By Role Name
+                foreach (var entry in list.List)
+                    if (!string.IsNullOrWhiteSpace(entry.Name) &&
+                        gu.Roles.Any(r => string.Equals(r.Name, entry.Name, StringComparison.OrdinalIgnoreCase)))
+                        return true;
+            }
+            return false;
+        }
+    }
+}

--- a/SysBot.Pokemon.Discord/Helpers/AutoLegalityExtensionsDiscord.cs
+++ b/SysBot.Pokemon.Discord/Helpers/AutoLegalityExtensionsDiscord.cs
@@ -69,7 +69,7 @@ public static class AutoLegalityExtensionsDiscord
             var successMsg = $" Aqui esta tu **{speciesName}** legalizado.";
             bool canGmax = pkm is PK8 pk8 && pk8.CanGigantamax;
 
-            var speciesImageUrl = Helpers.TradeExtensions<PK9>.PokeImg(pkm, canGmax, false);
+            var speciesImageUrl = SysBot.Pokemon.Helpers.TradeExtensions<PK9>.PokeImg(pkm, canGmax, false);
             // Create RegenTemplate from the legalized PKM
             var regenTemplate = new RegenTemplate(pkm);
             var regenText = regenTemplate.Text;
@@ -173,19 +173,19 @@ public static class AutoLegalityExtensionsDiscord
 
         if (pkm is PK8 pk8)
         {
-            pokeImgUrl = Helpers.TradeExtensions<PK8>.PokeImg(pk8, false, false);
+            pokeImgUrl = SysBot.Pokemon.Helpers.TradeExtensions<PK8>.PokeImg(pk8, false, false);
         }
         else if (pkm is PK9 pk9)
         {
-            pokeImgUrl = Helpers.TradeExtensions<PK9>.PokeImg(pk9, false, false);
+            pokeImgUrl = SysBot.Pokemon.Helpers.TradeExtensions<PK9>.PokeImg(pk9, false, false);
         }
         else if (pkm is PB8 pb8)
         {
-            pokeImgUrl = Helpers.TradeExtensions<PB8>.PokeImg(pb8, false, false);
+            pokeImgUrl = SysBot.Pokemon.Helpers.TradeExtensions<PB8>.PokeImg(pb8, false, false);
         }
         else if (pkm is PA8 pa8)
         {
-            pokeImgUrl = Helpers.TradeExtensions<PB8>.PokeImg(pa8, false, false);
+            pokeImgUrl = SysBot.Pokemon.Helpers.TradeExtensions<PB8>.PokeImg(pa8, false, false);
         }
 
         if (pokeImgUrl == null)

--- a/SysBot.Pokemon.Discord/Helpers/BattleReadyPlusQuotaTracker.cs
+++ b/SysBot.Pokemon.Discord/Helpers/BattleReadyPlusQuotaTracker.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Concurrent;
+
+namespace SysBot.Pokemon.Discord.Helpers
+{
+    public static class BattleReadyPlusQuotaTracker
+    {
+        private static readonly ConcurrentDictionary<(ulong UserId, DateOnly Day), int> Counts = new();
+
+        private static (ulong, DateOnly) Key(ulong userId) => (userId, DateOnly.FromDateTime(DateTime.UtcNow));
+
+        public static int GetTodayCount(ulong userId) => Counts.TryGetValue(Key(userId), out var v) ? v : 0;
+
+        public static int Increment(ulong userId) => Counts.AddOrUpdate(Key(userId), 1, (_, oldVal) => oldVal + 1);
+
+        public static void CleanupOld()
+        {
+            var today = DateOnly.FromDateTime(DateTime.UtcNow);
+            foreach (var k in Counts.Keys)
+                if (k.Day != today)
+                    Counts.TryRemove(k, out _);
+        }
+    }
+}

--- a/SysBot.Pokemon.Discord/Helpers/DiscordManager.cs
+++ b/SysBot.Pokemon.Discord/Helpers/DiscordManager.cs
@@ -29,6 +29,7 @@ public class DiscordManager(DiscordSettings Config)
     public RemoteControlAccessList RolesTrade => Config.RoleCanTrade;
 
     public RemoteControlAccessList RolesTradePlus => Config.RoleCanTradePlus;
+    public RemoteControlAccessList RolesTradePlusUnlimited => Config.RoleCanTradePlusUnlimited;
 
     public RemoteControlAccessList SudoDiscord => Config.GlobalSudoList;
 
@@ -68,6 +69,7 @@ public class DiscordManager(DiscordSettings Config)
         nameof(RolesClone) => RolesClone,
         nameof(RolesTrade) => RolesTrade,
         nameof(RolesTradePlus) => RolesTradePlus,
+        nameof(RolesTradePlusUnlimited) => RolesTradePlusUnlimited,
         nameof(RolesSeed) => RolesSeed,
         nameof(RolesDump) => RolesDump,
         nameof(RolesFixOT) => RolesFixOT,

--- a/SysBot.Pokemon/Settings/Integrations/DiscordSettings.cs
+++ b/SysBot.Pokemon/Settings/Integrations/DiscordSettings.cs
@@ -229,6 +229,8 @@ public class DiscordSettings
 
     [Category(Roles), Description("Los usuarios con esta función pueden utilizar las funciones Trade Adicionales.")]
     public RemoteControlAccessList RoleCanTradePlus { get; set; } = new() { AllowIfEmpty = true };
+    [Category(Roles), Description("Los usuarios con esta función pueden utilizar las funciones Trade Plus ilimitadas.")]
+    public RemoteControlAccessList RoleCanTradePlusUnlimited { get; set; } = new() { AllowIfEmpty = true };
 
     [Category(Roles), Description("Los usuarios con este rol pueden unirse a la cola con una mejor posición.")]
     public RemoteControlAccessList RoleFavored { get; set; } = new() { AllowIfEmpty = false };
@@ -296,3 +298,6 @@ public class Badge
 
     public override string ToString() => $"{Emoji}";
 }
+
+    [Category(Operation), Description("Límite diario de solicitudes BattleReady para usuarios con rol Plus (0 = sin límite).")]
+    public int BattleReadyPlusDailyLimit { get; set; } = 10;


### PR DESCRIPTION
- Se agregó nueva opcion para limitar pokemon generados con el rol "Rolecantradeplus"
- Se agregó nuevo Rol "Rolecantradeplusunlimited" para generar pokemon de BattleReady de manera ilimitada
- Se añadio texto para avisar cuando llegastes al limite de Pokemon generados con el rol "Rolecantradeplus"